### PR TITLE
feat: add docker args option to create CLI command

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,9 @@
+name: Autorelease
+
 on:
   push:
     branches:
       - main
-
-name: Autorelease
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ npx docker-build-info create -p "buildVersion=v1.2.0--test-build-1" -p "isTestBu
 
 And if you're running this as part of a docker image build, the CLI can give you some easy-to-use build arguments to add this info directly onto your docker image
 ```
-docker build $(npx docker-build-info docker-args) .
+docker build . $(npx docker-build-info docker-args)
+```
+
+You can even do everything at once
+```
+docker build . $(npx docker-build-info create -p "buildVersion=v1.2.0--test-build-1" -p "isTestBuild=true" --dockerArgs)
 ```
 
 #### API
@@ -66,7 +71,7 @@ async function buildDockerImage (customBuildVersion) {
     }
   })
 
-  execSync(`docker build . ${ dockerBuildInfo.getDockerBuildArgs(buildInfo)}`)
+  execSync(`docker build . ${dockerBuildInfo.getDockerBuildArgs(buildInfo)}`)
 }
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -28,6 +28,9 @@ sywac
           desc: 'Path of build info file',
           defaultValue: FILE_PATH_DEFAULT
         })
+        .boolean('-d, --dockerArgs', {
+          desc: 'Output docker args from created build info'
+        })
     },
     run: runCreateCommand
   })
@@ -79,9 +82,10 @@ sywac
 
 async function runCreateCommand (argv, context) {
   const {
+    debug,
+    dockerArgs,
     filePath,
-    prop,
-    debug
+    prop
   } = argv
 
   const logger = await getLogger(debug)
@@ -95,6 +99,11 @@ async function runCreateCommand (argv, context) {
   })
 
   logger?.info?.(JSON.stringify(buildInfo, undefined, 2))
+
+  if (dockerArgs) {
+    const dockerArgs = getDockerBuildArgs(buildInfo)
+    writeStdOut(dockerArgs)
+  }
 }
 
 async function runBuildVersionCommand (argv, context) {


### PR DESCRIPTION
for those wanting to do everything in a single command, can now use `-d` or `--dockerArgs` on the `create` command to return docker arguments after the build info file has been created

```
docker-build-info create -p "buildVersion=v1.2.0--test-build-1" -p "isTestBuild=true" --dockerArgs 
```

and that should return the docker args from the new create file
```
--label "buildId=1702489531753" --label "buildTimestamp=2023-12-13T17:45:31.753Z" --label "buildVersion=v1.2.0--test-build-1" --label "commitSha=2ce10138e25a453cdd87e227ddef31b7a72659c8" --label "commitStatus=clean" --label "commitTitle=test commit" --label "isTestBuild=true"
```

